### PR TITLE
Add CPP pragmas for Plutus version

### DIFF
--- a/ply-core/ply-core.cabal
+++ b/ply-core/ply-core.cabal
@@ -5,6 +5,11 @@ author:             Chase <chase@mlabs.city>
 license:            MIT
 extra-source-files: ../README.md
 
+flag plutus-new
+  description: Use the new plutus-ledger-api namespace (0a8b1ad)
+  manual:      True
+  default:     False
+
 -- Common sections
 
 common common-configs
@@ -41,6 +46,7 @@ common common-lang
     BinaryLiterals
     ConstrainedClassMethods
     ConstraintKinds
+    CPP
     DataKinds
     DeriveAnyClass
     DeriveDataTypeable
@@ -107,6 +113,9 @@ library
     Ply.Core.UPLC
 
   hs-source-dirs:  src
+
+  if flag(plutus-new)
+    cpp-options: -DPLUTUS_NEW
 
 test-suite ply-core-test
   import:         common-lang

--- a/ply-core/src/Ply.hs
+++ b/ply-core/src/Ply.hs
@@ -19,11 +19,19 @@ module Ply (
 
 import Data.Coerce (coerce)
 
+#if PLUTUS_NEW
+import PlutusLedgerApi.V1.Scripts (
+  MintingPolicy (MintingPolicy),
+  Script (Script),
+  Validator (Validator),
+ )
+#else
 import Plutus.V1.Ledger.Scripts (
   MintingPolicy (MintingPolicy),
   Script (Script),
   Validator (Validator),
  )
+#endif
 
 import Ply.Core.Apply ((#), (#!), (#$), (#$!))
 import Ply.Core.Class (PlyArg)

--- a/ply-core/src/Ply/Core/Class.hs
+++ b/ply-core/src/Ply/Core/Class.hs
@@ -12,10 +12,17 @@ import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import GHC.TypeLits (ErrorMessage (ShowType, Text))
 
+#ifdef PLUTUS_NEW
+import PlutusLedgerApi.V1
+import PlutusLedgerApi.V1.Scripts
+import PlutusLedgerApi.V1.Time
+import PlutusLedgerApi.V1.Value
+#else
 import Plutus.V1.Ledger.Api
 import Plutus.V1.Ledger.Scripts
 import Plutus.V1.Ledger.Time
 import Plutus.V1.Ledger.Value
+#endif
 import PlutusCore (DefaultUni, Includes, Some, ValueOf)
 import qualified PlutusCore as PLC
 import qualified PlutusTx.AssocMap as PlutusMap

--- a/ply-core/src/Ply/Core/Deserialize.hs
+++ b/ply-core/src/Ply/Core/Deserialize.hs
@@ -12,7 +12,11 @@ import qualified Data.Aeson as Aeson
 
 import Cardano.Binary (DecoderError, FromCBOR (fromCBOR))
 import qualified Cardano.Binary as CBOR
+#ifdef PLUTUS_NEW
+import qualified PlutusLedgerApi.V1.Scripts as PlutusScript
+#else
 import qualified Plutus.V1.Ledger.Scripts as PlutusScript
+#endif
 
 import Ply.Core.Types (
   ScriptReaderException (AesonDecodeError, CBORDecodeError),

--- a/ply-core/src/Ply/Core/Serialize.hs
+++ b/ply-core/src/Ply/Core/Serialize.hs
@@ -10,7 +10,11 @@ import Data.Text (Text)
 import qualified Data.Text.Encoding as Txt
 
 import qualified Cardano.Binary as CBOR
+#ifdef PLUTUS_NEW
+import PlutusLedgerApi.V1.Scripts (Script)
+#else
 import Plutus.V1.Ledger.Scripts (Script)
+#endif
 
 import Ply.Core.Types (
   ScriptRole,

--- a/ply-core/src/Ply/Core/TypedReader.hs
+++ b/ply-core/src/Ply/Core/TypedReader.hs
@@ -8,7 +8,11 @@ import Data.Kind (Constraint, Type)
 import Data.Proxy (Proxy (Proxy))
 import Data.Typeable (Typeable)
 
+#ifdef PLUTUS_NEW
+import PlutusLedgerApi.V1.Scripts (Script (Script))
+#else
 import Plutus.V1.Ledger.Scripts (Script (Script))
+#endif
 
 import Ply.Core.Deserialize (readEnvelope)
 import Ply.Core.Types (

--- a/ply-core/src/Ply/Core/Types.hs
+++ b/ply-core/src/Ply/Core/Types.hs
@@ -34,7 +34,11 @@ import Data.Aeson.Types (
  )
 
 import Cardano.Binary (DecoderError)
+#if PLUTUS_NEW
+import PlutusLedgerApi.V1.Scripts (Script)
+#else
 import Plutus.V1.Ledger.Scripts (Script)
+#endif
 import UntypedPlutusCore (DeBruijn, DefaultFun, DefaultUni, Program)
 
 -- | Compiled scripts that preserve script role and parameter types.

--- a/ply-plutarch/ply-plutarch.cabal
+++ b/ply-plutarch/ply-plutarch.cabal
@@ -5,6 +5,11 @@ author:             Chase <chase@mlabs.city>
 license:            MIT
 extra-source-files: ../README.md
 
+flag plutus-new
+  description: Use the new plutus-ledger-api namespace (0a8b1ad)
+  manual:      True
+  default:     False
+
 -- Common sections
 
 common common-configs
@@ -36,6 +41,7 @@ common common-lang
     BinaryLiterals
     ConstrainedClassMethods
     ConstraintKinds
+    CPP
     DataKinds
     DeriveAnyClass
     DeriveDataTypeable
@@ -95,6 +101,9 @@ library
     Ply.Plutarch.TypedWriter
 
   hs-source-dirs:  src
+
+  if flag(plutus-new)
+    cpp-options: -DPLUTUS_NEW
 
 test-suite ply-plutarch-test
   import:         common-lang

--- a/ply-plutarch/src/Ply/Plutarch/Class.hs
+++ b/ply-plutarch/src/Ply/Plutarch/Class.hs
@@ -7,7 +7,11 @@ import Data.Text (Text)
 
 import Plutarch.Api.V1
 import Plutarch.Prelude
+#ifdef PLUTUS_NEW
+import PlutusLedgerApi.V1
+#else
 import Plutus.V1.Ledger.Api
+#endif
 import qualified PlutusTx.AssocMap as PlutusMap
 
 -- TODO: How to handle 'PAsData'?

--- a/ply-plutarch/src/Ply/Plutarch/TypedWriter.hs
+++ b/ply-plutarch/src/Ply/Plutarch/TypedWriter.hs
@@ -10,7 +10,11 @@ import GHC.TypeLits (ErrorMessage (ShowType, Text, (:$$:), (:<>:)), TypeError)
 
 import Plutarch (ClosedTerm, PType, compile, type (:-->))
 import Plutarch.Api.V1 (PMintingPolicy, PValidator)
+#ifdef PLUTUS_NEW
+import PlutusLedgerApi.V1.Scripts (Script)
+#else
 import Plutus.V1.Ledger.Scripts (Script)
+#endif
 
 import Ply (ScriptRole (MintingPolicyRole, ValidatorRole), Typename, typeName)
 import Ply.Core.Serialize (writeEnvelope)

--- a/ply-plutarch/test/Spec.hs
+++ b/ply-plutarch/test/Spec.hs
@@ -9,7 +9,11 @@ import Test.Tasty.HUnit
 
 import Plutarch.Api.V1
 import Plutarch.Prelude
+#ifdef PLUTUS_NEW
+import PlutusLedgerApi.V1
+#else
 import Plutus.V1.Ledger.Api
+#endif
 import qualified PlutusTx.AssocMap as PlutusMap
 
 import Ply (ScriptRole (MintingPolicyRole, ValidatorRole), Typename, typeName)


### PR DESCRIPTION
There may be nicer ways to achieve this (maybe by conditionally re-exporting modules?), but something to this effect will support more dependency configurations using the plutus-scaffold base.