### PR TITLE
PlutusV2

### DIFF
--- a/example/flake.lock
+++ b/example/flake.lock
@@ -3596,12 +3596,12 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-aAlZn9j2hWF2iuwQU4zHHxx0l7KI8AsyjIac1niEnb8=",
-        "path": "/nix/store/r0nds7fliigpqwqq0c350hd3bafjb1zx-source",
+        "narHash": "sha256-RLic2t9fX4fzJDBuw8d8vLTOsLektrAWxPzENwzg2Hg=",
+        "path": "/nix/store/1f7bdi16lhgx03586qgxg3yi57sy0744-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/r0nds7fliigpqwqq0c350hd3bafjb1zx-source",
+        "path": "/nix/store/1f7bdi16lhgx03586qgxg3yi57sy0744-source",
         "type": "path"
       }
     },

--- a/example/offchain/app/Main.hs
+++ b/example/offchain/app/Main.hs
@@ -22,6 +22,7 @@ import Test.Plutip.LocalCluster (
 
 import Ledger (PaymentPubKeyHash (PaymentPubKeyHash))
 import Ply (readTypedScript)
+import qualified Ply
 
 import Example.Nft (
   MintParams (
@@ -39,6 +40,10 @@ main = do
   -- Start the node.
   (clusterStat, (cEnv, ownWallet)) <- startCluster def setup
   nftMp <- readTypedScript $ "../" </> "compiled" </> "nftMp.plutus"
+
+  -- Print the Plutus ledger version used by the minting policy.
+  putStr "NFT Minting Policy version: "
+  print $ Ply.getPlutusVersion nftMp
 
   -- Do stuff.
   ExecutionResult exOutcome _ _ _ <-

--- a/ply-core/ply-core.cabal
+++ b/ply-core/ply-core.cabal
@@ -103,6 +103,7 @@ library
     Ply.Core.Apply
     Ply.Core.Class
     Ply.Core.Deserialize
+    Ply.Core.Internal.Reify
     Ply.Core.Serialize
     Ply.Core.TypedReader
 

--- a/ply-core/src/Ply.hs
+++ b/ply-core/src/Ply.hs
@@ -7,6 +7,7 @@ module Ply (
   Typename,
   typeName,
   PlyArg,
+  getPlutusVersion,
   toValidator,
   toScript,
   toMintingPolicy,
@@ -38,14 +39,18 @@ import Ply.Core.Types (
   Typename,
  )
 
+-- | Obtain the Plutus script (ledger) version associated with given 'TypedScript'.
+getPlutusVersion :: TypedScript r params -> ScriptVersion
+getPlutusVersion (TypedScript ver _) = ver
+
 -- | Obtain a 'Validator' from a 'TypedScript'.
 toValidator :: TypedScript 'ValidatorRole '[] -> Validator
-toValidator (TypedScript s) = coerce s
+toValidator (TypedScript _ s) = coerce s
 
 -- | Obtain a 'MintingPolicy' from a 'TypedScript'.
 toMintingPolicy :: TypedScript 'MintingPolicyRole '[] -> MintingPolicy
-toMintingPolicy (TypedScript s) = coerce s
+toMintingPolicy (TypedScript _ s) = coerce s
 
 -- | Unconditionally obtain the raw untyped 'Script' from a 'TypedScript'.
 toScript :: TypedScript r params -> Script
-toScript (TypedScript s) = coerce s
+toScript (TypedScript _ s) = coerce s

--- a/ply-core/src/Ply.hs
+++ b/ply-core/src/Ply.hs
@@ -39,15 +39,46 @@ import Ply.Core.Types (
   Typename,
  )
 
--- | Obtain the Plutus script (ledger) version associated with given 'TypedScript'.
+{- | Obtain the Plutus script (ledger) version associated with given 'TypedScript'.
+
+You can utilize this function to hook up offchain utilities that attach scripts to
+a contract. Because 'TypedScript's carry around their Plutus version - you can safely
+use 'getPlutusVersion' to determine whether you should declare the validator/minting policy
+as V1 or V2 before attaching it to the Contract.
+
+For example, if using 'plutus-apps' - you can create a function that determines whether to use
+`plutusV1OtherScript` or `plutusV2OtherScript` in your script lookups:
+
+@
+unifiedOtherScript :: TypedScript ValidatorRole '[] -> ScriptLookups a
+unifiedOtherScript ts = (if ver == ScriptV1 then plutusV1OtherScript else plutusV2OtherScript) vald
+  where
+    ver = getPlutusVersion ts
+    vald = Ply.toValidator ts
+@
+-}
 getPlutusVersion :: TypedScript r params -> ScriptVersion
 getPlutusVersion (TypedScript ver _) = ver
 
--- | Obtain a 'Validator' from a 'TypedScript'.
+{- | Obtain a 'Validator' from a 'TypedScript'.
+
+Because of Ply's Plutus version and type tracking capabilities - it is recommended that you
+keep your scripts as 'TypedScript's for as long as possible. This can allow you to create useful
+utilities that only use 'toValidator' and 'toMintingPolicy' as a final processing step.
+
+See: 'getPlutusVersion' for an example of such a utility.
+-}
 toValidator :: TypedScript 'ValidatorRole '[] -> Validator
 toValidator (TypedScript _ s) = coerce s
 
--- | Obtain a 'MintingPolicy' from a 'TypedScript'.
+{- | Obtain a 'MintingPolicy' from a 'TypedScript'.
+
+Because of Ply's Plutus version and type tracking capabilities - it is recommended that you
+keep your scripts as 'TypedScript's for as long as possible. This can allow you to create useful
+utilities that only use 'toValidator' and 'toMintingPolicy' as a final processing step.
+
+See: 'getPlutusVersion' for an example of such a utility.
+-}
 toMintingPolicy :: TypedScript 'MintingPolicyRole '[] -> MintingPolicy
 toMintingPolicy (TypedScript _ s) = coerce s
 

--- a/ply-core/src/Ply.hs
+++ b/ply-core/src/Ply.hs
@@ -53,7 +53,7 @@ For example, if using 'plutus-apps' - you can create a function that determines 
 unifiedOtherScript :: TypedScript ValidatorRole '[] -> ScriptLookups a
 unifiedOtherScript ts = (if ver == ScriptV1 then plutusV1OtherScript else plutusV2OtherScript) vald
   where
-    ver = getPlutusVersion ts
+    ver = Ply.getPlutusVersion ts
     vald = Ply.toValidator ts
 @
 -}

--- a/ply-core/src/Ply/Core/Apply.hs
+++ b/ply-core/src/Ply/Core/Apply.hs
@@ -6,11 +6,11 @@ import Ply.Core.UPLC (applyConstant, applyConstant')
 
 -- | Apply a parameter with a known type to given 'TypedScript'.
 applyParam :: PlyArg x => TypedScript r (x : xs) -> x -> TypedScript r xs
-applyParam (TypedScript prog) x = TypedScript $ prog `applyConstant` someBuiltinArg x
+applyParam (TypedScript ver prog) x = TypedScript ver $ prog `applyConstant` someBuiltinArg x
 
 -- | Like 'applyParam' but does not perform any optimizations, making the final AST predictable.
 applyParam' :: PlyArg x => TypedScript r (x : xs) -> x -> TypedScript r xs
-applyParam' (TypedScript prog) x = TypedScript $ prog `applyConstant'` someBuiltinArg x
+applyParam' (TypedScript ver prog) x = TypedScript ver $ prog `applyConstant'` someBuiltinArg x
 
 {- | Operator version of 'applyParam', to be used as juxtaposition.
 

--- a/ply-core/src/Ply/Core/Class.hs
+++ b/ply-core/src/Ply/Core/Class.hs
@@ -28,7 +28,7 @@ associated invariants the type may have. It may also _normalize_ types.
 
 As a result, 'toBuiltinArg' is partial for types that don't hold their invariants.
 -}
-class (DefaultUni `Includes` UPLCRep a) => PlyArg a where
+class DefaultUni `Includes` UPLCRep a => PlyArg a where
   type UPLCRep a :: Type
   type ToDataConstraint a :: Constraint
   type ToDataConstraint a = ()

--- a/ply-core/src/Ply/Core/Internal/Reify.hs
+++ b/ply-core/src/Ply/Core/Internal/Reify.hs
@@ -1,0 +1,38 @@
+module Ply.Core.Internal.Reify (ReifyVersion (reifyVersion), ReifyRole (reifyRole), ReifyTypenames (reifyTypenames)) where
+
+import Data.Kind (Constraint, Type)
+import Data.Proxy (Proxy (Proxy))
+import Type.Reflection (Typeable)
+
+import Ply.Core.Typename (typeName)
+import Ply.Core.Types
+
+type ReifyVersion :: ScriptVersion -> Constraint
+class ReifyVersion s where
+  reifyVersion :: Proxy s -> ScriptVersion
+
+type ReifyRole :: ScriptRole -> Constraint
+class ReifyRole s where
+  reifyRole :: Proxy s -> ScriptRole
+
+type ReifyTypenames :: [Type] -> Constraint
+class ReifyTypenames ts where
+  reifyTypenames :: Proxy ts -> [Typename]
+
+instance ReifyVersion ScriptV1 where
+  reifyVersion _ = ScriptV1
+
+instance ReifyVersion ScriptV2 where
+  reifyVersion _ = ScriptV2
+
+instance ReifyRole ValidatorRole where
+  reifyRole _ = ValidatorRole
+
+instance ReifyRole MintingPolicyRole where
+  reifyRole _ = MintingPolicyRole
+
+instance ReifyTypenames '[] where
+  reifyTypenames _ = []
+
+instance (Typeable x, ReifyTypenames xs) => ReifyTypenames (x : xs) where
+  reifyTypenames _ = typeName @x : reifyTypenames (Proxy @xs)

--- a/ply-core/src/Ply/Core/Serialize.hs
+++ b/ply-core/src/Ply/Core/Serialize.hs
@@ -13,7 +13,7 @@ import qualified Cardano.Binary as CBOR
 
 import Ply.Core.Types (
   ScriptRole,
-  ScriptVersion (ScriptV1),
+  ScriptVersion,
   TypedScriptEnvelope' (..),
   Typename,
  )
@@ -31,12 +31,14 @@ serializeScriptCbor = CBOR.serialize' . SBS.toShort . serializeScript
 serializeScriptCborHex :: Script -> Text
 serializeScriptCborHex = Txt.decodeUtf8 . Base16.encode . serializeScriptCbor
 
--- | Write a typed script into a 'TypedScriptEnvelope'.
+-- | Write a typed script into a "Ply.Core.Types.TypedScriptEnvelope".
 writeEnvelope ::
   -- | Description for the script (semantically irrelevant).
   Text ->
   -- | Path to write the file to.
   FilePath ->
+  -- | Version of the script.
+  ScriptVersion ->
   -- | Whether the script is a validator or a minting policy.
   ScriptRole ->
   -- | The extra parameter types for the script.
@@ -44,10 +46,10 @@ writeEnvelope ::
   -- | The script itself.
   Script ->
   IO ()
-writeEnvelope descr filepath scrptRole paramTypes scrpt = do
+writeEnvelope descr filepath scrptVer scrptRole paramTypes scrpt = do
   let plutusEnvelope =
         TypedScriptEnvelope'
-          { tsVersion' = ScriptV1
+          { tsVersion' = scrptVer
           , tsRole' = scrptRole
           , tsParamTypes' = paramTypes
           , tsDescription' = descr

--- a/ply-core/src/Ply/Core/TypedReader.hs
+++ b/ply-core/src/Ply/Core/TypedReader.hs
@@ -20,9 +20,12 @@ import Ply.Core.Types (
 import Ply.LedgerExports.Common (Script (Script))
 
 class TypedReader_ r params where
+  -- | Pure function to parse a 'TypedScript' from a 'TypedScriptEnvelope'.
   mkTypedScript :: TypedScriptEnvelope -> Either ScriptReaderException (TypedScript r params)
 
+-- | Class of 'TypedScript' parameters that are supported and can be read.
 class TypedReader_ r params => TypedReader r params
+
 instance TypedReader_ r params => TypedReader r params
 
 {- | Read and verify a 'TypedScript' from given filepath.
@@ -39,18 +42,18 @@ readTypedScript ::
 readTypedScript p = readEnvelope p >>= either throwIO pure . mkTypedScript
 
 instance MkTypenames params => TypedReader_ ValidatorRole params where
-  mkTypedScript (TypedScriptEnvelope _ rol params _ (Script prog)) = do
+  mkTypedScript (TypedScriptEnvelope ver rol params _ (Script prog)) = do
     unless (rol == ValidatorRole) . Left $ ScriptRoleError ValidatorRole rol
     let expectedParams = mkTypenames $ Proxy @params
     unless (expectedParams == params) . Left $ ScriptTypeError expectedParams params
-    pure $ TypedScript prog
+    pure $ TypedScript ver prog
 
 instance MkTypenames params => TypedReader_ MintingPolicyRole params where
-  mkTypedScript (TypedScriptEnvelope _ rol params _ (Script prog)) = do
+  mkTypedScript (TypedScriptEnvelope ver rol params _ (Script prog)) = do
     unless (rol == MintingPolicyRole) . Left $ ScriptRoleError MintingPolicyRole rol
     let expectedParams = mkTypenames $ Proxy @params
     unless (expectedParams == params) . Left $ ScriptTypeError expectedParams params
-    pure $ TypedScript prog
+    pure $ TypedScript ver prog
 
 type MkTypenames :: [Type] -> Constraint
 class MkTypenames a where

--- a/ply-core/src/Ply/Core/TypedReader.hs
+++ b/ply-core/src/Ply/Core/TypedReader.hs
@@ -4,29 +4,38 @@ module Ply.Core.TypedReader (TypedReader, readTypedScript, mkTypedScript) where
 
 import Control.Exception (throwIO)
 import Control.Monad (unless)
-import Data.Kind (Constraint, Type)
 import Data.Proxy (Proxy (Proxy))
-import Data.Typeable (Typeable)
 
 import Ply.Core.Deserialize (readEnvelope)
-import Ply.Core.Typename (typeName)
+import Ply.Core.Internal.Reify
 import Ply.Core.Types (
   ScriptReaderException (ScriptRoleError, ScriptTypeError),
-  ScriptRole (MintingPolicyRole, ValidatorRole),
+  ScriptRole (ValidatorRole),
   TypedScript (TypedScript),
   TypedScriptEnvelope (TypedScriptEnvelope),
-  Typename,
  )
 import Ply.LedgerExports.Common (Script (Script))
 
-class TypedReader_ r params where
-  -- | Pure function to parse a 'TypedScript' from a 'TypedScriptEnvelope'.
-  mkTypedScript :: TypedScriptEnvelope -> Either ScriptReaderException (TypedScript r params)
+{- | Class of 'TypedScript' parameters that are supported and can be read.
 
--- | Class of 'TypedScript' parameters that are supported and can be read.
-class TypedReader_ r params => TypedReader r params
+See: 'mkTypedScript'.
+-}
+type TypedReader rl params =
+  ( ReifyRole rl
+  , ReifyTypenames params
+  )
 
-instance TypedReader_ r params => TypedReader r params
+-- | Pure function to parse a 'TypedScript' from a 'TypedScriptEnvelope'.
+mkTypedScript ::
+  forall rl params.
+  TypedReader rl params =>
+  TypedScriptEnvelope ->
+  Either ScriptReaderException (TypedScript rl params)
+mkTypedScript (TypedScriptEnvelope ver rol params _ (Script prog)) = do
+  unless (rol == reifyRole (Proxy @rl)) . Left $ ScriptRoleError ValidatorRole rol
+  let expectedParams = reifyTypenames $ Proxy @params
+  unless (expectedParams == params) . Left $ ScriptTypeError expectedParams params
+  pure $ TypedScript ver prog
 
 {- | Read and verify a 'TypedScript' from given filepath.
 
@@ -40,27 +49,3 @@ readTypedScript ::
   FilePath ->
   IO (TypedScript r params)
 readTypedScript p = readEnvelope p >>= either throwIO pure . mkTypedScript
-
-instance MkTypenames params => TypedReader_ ValidatorRole params where
-  mkTypedScript (TypedScriptEnvelope ver rol params _ (Script prog)) = do
-    unless (rol == ValidatorRole) . Left $ ScriptRoleError ValidatorRole rol
-    let expectedParams = mkTypenames $ Proxy @params
-    unless (expectedParams == params) . Left $ ScriptTypeError expectedParams params
-    pure $ TypedScript ver prog
-
-instance MkTypenames params => TypedReader_ MintingPolicyRole params where
-  mkTypedScript (TypedScriptEnvelope ver rol params _ (Script prog)) = do
-    unless (rol == MintingPolicyRole) . Left $ ScriptRoleError MintingPolicyRole rol
-    let expectedParams = mkTypenames $ Proxy @params
-    unless (expectedParams == params) . Left $ ScriptTypeError expectedParams params
-    pure $ TypedScript ver prog
-
-type MkTypenames :: [Type] -> Constraint
-class MkTypenames a where
-  mkTypenames :: Proxy a -> [Typename]
-
-instance MkTypenames '[] where
-  mkTypenames _ = []
-
-instance (Typeable x, MkTypenames xs) => MkTypenames (x ': xs) where
-  mkTypenames _ = typeName @x : mkTypenames (Proxy @xs)

--- a/ply-core/src/Ply/Core/Types.hs
+++ b/ply-core/src/Ply/Core/Types.hs
@@ -38,7 +38,7 @@ import Ply.LedgerExports.Common (Script)
 type role TypedScript nominal nominal
 
 type TypedScript :: ScriptRole -> [Type] -> Type
-newtype TypedScript r a = TypedScript (Program DeBruijn DefaultUni DefaultFun ())
+data TypedScript r a = TypedScript !ScriptVersion !(Program DeBruijn DefaultUni DefaultFun ())
   deriving stock (Show)
 
 -- | Script role: either a validator or a minting policy.

--- a/ply-plutarch/src/Ply/Plutarch/TypedWriter.hs
+++ b/ply-plutarch/src/Ply/Plutarch/TypedWriter.hs
@@ -94,7 +94,7 @@ instance (Typeable x, ReifyTypenames xs) => ReifyTypenames (x : xs) where
 >>> :k! ParamsOf (PByteString :--> PData :--> PScriptContext :--> POpaque)
 [PByteString]
 
-=== Note ===
+=== Note
 Indeed, there is a possibility for ambiguity here. Is `PData :--> PData :--> PScriptContext :--> POpaque` a
 minting policy with an extra 'PData' parameter? Or is it a validator?
 
@@ -124,7 +124,7 @@ MintingPolicyRole
 >>> :k! RoleOf (PByteString :--> PData :--> PScriptContext :--> POpaque)
 MintingPolicyRole
 
-=== Note ===
+=== Note
 Indeed, there is a possibility for ambiguity here. Is `PData :--> PData :--> PScriptContext :--> POpaque` a
 minting policy with an extra 'PData' parameter? Or is it a validator?
 

--- a/ply-plutarch/src/Ply/Plutarch/TypedWriter.hs
+++ b/ply-plutarch/src/Ply/Plutarch/TypedWriter.hs
@@ -14,7 +14,7 @@ import Plutarch (ClosedTerm, Config, PType, compile, type (:-->))
 import Plutarch.Api.V1 (PMintingPolicy, PValidator)
 import PlutusLedgerApi.V1.Scripts (Script)
 
-import Ply (ScriptRole (MintingPolicyRole, ValidatorRole), Typename, typeName)
+import Ply (ScriptRole (MintingPolicyRole, ValidatorRole), ScriptVersion (ScriptV1), Typename, typeName)
 import Ply.Core.Serialize (writeEnvelope)
 import Ply.Plutarch.Class (PlyArgOf)
 
@@ -34,7 +34,7 @@ writeTypedScript ::
   ClosedTerm pt ->
   IO ()
 writeTypedScript conf descr fp target =
-  either (throwIO . userError . Txt.unpack) (writeEnvelope descr fp rl paramTypes) scrpt
+  either (throwIO . userError . Txt.unpack) (writeEnvelope descr fp ScriptV1 rl paramTypes) scrpt
   where
     (rl, paramTypes, scrpt) = typedWriterInfo conf target
 


### PR DESCRIPTION
Adding PlutusV2 support.

This will include a super ergonomic mechanism that will _auto distinguish_ between V1 and V2 Plutarch scripts. The user doesn't have to care - `ply-plutarch` will figure it out, and `ply-core` will read it back.

Closing #10 