### PR TITLE
Export missing `PlyArg` methods/types and update to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1 - Hot fix for `PlyArg`
+
+- Export `ToDataConstraint` and `toBuiltinArgData`.
+
 # 0.1.0 - Initial Release
 
 - Full Plutus V2 support with machinery for distinguishing between V1 and V2 Plutarch scripts.

--- a/ply-core/ply-core.cabal
+++ b/ply-core/ply-core.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          ply-core
-version:       0.1.0
+version:       0.1.1
 author:        Chase <chase@mlabs.city>
 license:       MIT
 

--- a/ply-core/src/Ply/Core/Class.hs
+++ b/ply-core/src/Ply/Core/Class.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ply.Core.Class (PlyArg (UPLCRep, toBuiltinArg), someBuiltinArg) where
+module Ply.Core.Class (PlyArg (UPLCRep, ToDataConstraint, toBuiltinArg, toBuiltinArgData), someBuiltinArg) where
 
 import Data.Bifunctor (Bifunctor (bimap), second)
 import Data.ByteString (ByteString)

--- a/ply-plutarch/ply-plutarch.cabal
+++ b/ply-plutarch/ply-plutarch.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          ply-plutarch
-version:       0.1.0
+version:       0.1.1
 author:        Chase <chase@mlabs.city>
 license:       MIT
 


### PR DESCRIPTION
I forgot to export the `toBuiltinArgData` stuff since it's not actually used anywhere _yet_. It will be when I figure out `PlyArg (PlyArgOf a) => PAsData a` support.