### PR TITLE
0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.2.0 - Internal Type Cleanup
+
+- `TypedScriptEnvelope'` is deprecated. `TypedScriptEnvelope` now implements `toJSON` and `fromJSON` directly.
+- `writeEnvelope` and `readEnvelope` are updated to have more sensible types. They will read and write to and from `TypedScriptEnvelope`.
+- `mkEnvelope` at `Ply.Plutarch` will convert Plutarch term into `TypedScriptEnvelope` given config and description.
+- `CBORDecodeError` is removed, `AesonDecodeError` will be thrown when decoding error happen.
+- Script serialization utilites are now relocated to `Ply.Core.Serialize.Script`.
+
 # 0.1.3 - **Critical fix** for `PlyArg Extended` instance
 
 - The constructor indices were incorrect.

--- a/ply-core/ply-core.cabal
+++ b/ply-core/ply-core.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          ply-core
-version:       0.1.3
+version:       0.2.0
 author:        Chase <chase@mlabs.city>
 license:       MIT
 
@@ -105,6 +105,7 @@ library
     Ply.Core.Deserialize
     Ply.Core.Internal.Reify
     Ply.Core.Serialize
+    Ply.Core.Serialize.Script
     Ply.Core.TypedReader
 
   other-modules:

--- a/ply-core/src/Ply/Core/Deserialize.hs
+++ b/ply-core/src/Ply/Core/Deserialize.hs
@@ -1,39 +1,18 @@
 module Ply.Core.Deserialize (readEnvelope) where
 
 import Control.Exception (throwIO)
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
-import Data.ByteString.Short (ShortByteString)
-import qualified Data.ByteString.Short as SBS
 
-import Codec.Serialise (deserialise)
 import qualified Data.Aeson as Aeson
 
-import Cardano.Binary (DecoderError, FromCBOR (fromCBOR))
-import qualified Cardano.Binary as CBOR
-
 import Ply.Core.Types (
-  ScriptReaderException (AesonDecodeError, CBORDecodeError),
-  TypedScriptEnvelope (TypedScriptEnvelope),
-  TypedScriptEnvelope' (TypedScriptEnvelope'),
+  ScriptReaderException (AesonDecodeError),
+  TypedScriptEnvelope,
  )
-import qualified Ply.LedgerExports.Common as Ledger
 
 -- | Read a 'TypedScriptEnvelope'.
 readEnvelope :: FilePath -> IO TypedScriptEnvelope
 readEnvelope path = do
   content <- BS.readFile path
-  TypedScriptEnvelope' ver rol params desc cborHex _ <-
-    either (throwIO . AesonDecodeError) pure $
-      Aeson.eitherDecodeStrict' content
-  scrpt <- either (throwIO . CBORDecodeError) pure $ cborToScript cborHex
-  pure $ TypedScriptEnvelope ver rol params desc scrpt
-
-cborToScript :: ByteString -> Either DecoderError Ledger.Script
-cborToScript x = deserialise . LBS.fromStrict . SBS.fromShort . getSerializedScript <$> CBOR.decodeFull' x
-
-newtype SerializedScript = SerializedScript {getSerializedScript :: ShortByteString}
-
-instance FromCBOR SerializedScript where
-  fromCBOR = SerializedScript . SBS.toShort <$> CBOR.fromCBOR
+  either (throwIO . AesonDecodeError) pure $
+    Aeson.eitherDecodeStrict' content

--- a/ply-core/src/Ply/Core/Serialize.hs
+++ b/ply-core/src/Ply/Core/Serialize.hs
@@ -1,38 +1,23 @@
 module Ply.Core.Serialize (
   writeEnvelope,
   writeTypedScriptEnvolope,
-  serializeScript,
-  serializeScriptCbor,
   serializeScriptCborHex,
 ) where
 
-import Codec.Serialise (serialise)
 import Data.Aeson.Encode.Pretty (encodePretty)
-import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.ByteString.Short as SBS
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Txt
-
-import qualified Cardano.Binary as CBOR
 
 import Ply.Core.Types (
   ScriptRole,
   ScriptVersion,
   TypedScriptEnvelope (..),
-  TypedScriptEnvelope' (..),
   Typename,
+  serializeScriptCbor,
  )
 import Ply.LedgerExports.Common (Script)
-
--- | Serialize a script into its raw form.
-serializeScript :: Script -> ByteString
-serializeScript = LBS.toStrict . serialise
-
--- | Serialize a script into CBOR.
-serializeScriptCbor :: Script -> ByteString
-serializeScriptCbor = CBOR.serialize' . SBS.toShort . serializeScript
 
 -- | A showable hex string representing a serialized script in CBOR.
 serializeScriptCborHex :: Script -> Text
@@ -40,8 +25,8 @@ serializeScriptCborHex = Txt.decodeUtf8 . Base16.encode . serializeScriptCbor
 
 -- | Write 'TypedScriptEnvelop' into file.
 writeTypedScriptEnvolope :: FilePath -> TypedScriptEnvelope -> IO ()
-writeTypedScriptEnvolope filepath (TypedScriptEnvelope ver role param descr script) =
-  writeEnvelope descr filepath ver role param script
+writeTypedScriptEnvolope filepath =
+  LBS.writeFile filepath . encodePretty
 
 -- | Write a typed script into a "Ply.Core.Types.TypedScriptEnvelope".
 writeEnvelope ::
@@ -58,15 +43,7 @@ writeEnvelope ::
   -- | The script itself.
   Script ->
   IO ()
-writeEnvelope descr filepath scrptVer scrptRole paramTypes scrpt = do
+writeEnvelope descr filepath scrptVer scrptRole paramTypes scrpt =
   let plutusEnvelope =
-        TypedScriptEnvelope'
-          { tsVersion' = scrptVer
-          , tsRole' = scrptRole
-          , tsParamTypes' = paramTypes
-          , tsDescription' = descr
-          , tsCbor' = serializeScriptCbor scrpt
-          , tsRaw' = serializeScript scrpt
-          }
-      content = encodePretty plutusEnvelope
-  LBS.writeFile filepath content
+        TypedScriptEnvelope scrptVer scrptRole paramTypes descr scrpt
+   in writeTypedScriptEnvolope filepath plutusEnvelope

--- a/ply-core/src/Ply/Core/Serialize.hs
+++ b/ply-core/src/Ply/Core/Serialize.hs
@@ -1,49 +1,12 @@
 module Ply.Core.Serialize (
   writeEnvelope,
-  writeTypedScriptEnvolope,
-  serializeScriptCborHex,
 ) where
 
 import Data.Aeson.Encode.Pretty (encodePretty)
-import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as LBS
-import Data.Text (Text)
-import qualified Data.Text.Encoding as Txt
 
-import Ply.Core.Types (
-  ScriptRole,
-  ScriptVersion,
-  TypedScriptEnvelope (..),
-  Typename,
-  serializeScriptCbor,
- )
-import Ply.LedgerExports.Common (Script)
+import Ply.Core.Types (TypedScriptEnvelope (..))
 
--- | A showable hex string representing a serialized script in CBOR.
-serializeScriptCborHex :: Script -> Text
-serializeScriptCborHex = Txt.decodeUtf8 . Base16.encode . serializeScriptCbor
-
--- | Write 'TypedScriptEnvelop' into file.
-writeTypedScriptEnvolope :: FilePath -> TypedScriptEnvelope -> IO ()
-writeTypedScriptEnvolope filepath =
-  LBS.writeFile filepath . encodePretty
-
--- | Write a typed script into a "Ply.Core.Types.TypedScriptEnvelope".
-writeEnvelope ::
-  -- | Description for the script (semantically irrelevant).
-  Text ->
-  -- | Path to write the file to.
-  FilePath ->
-  -- | Version of the script.
-  ScriptVersion ->
-  -- | Whether the script is a validator or a minting policy.
-  ScriptRole ->
-  -- | The extra parameter types for the script.
-  [Typename] ->
-  -- | The script itself.
-  Script ->
-  IO ()
-writeEnvelope descr filepath scrptVer scrptRole paramTypes scrpt =
-  let plutusEnvelope =
-        TypedScriptEnvelope scrptVer scrptRole paramTypes descr scrpt
-   in writeTypedScriptEnvolope filepath plutusEnvelope
+-- | Write a `TypedScriptEnvelope` into the given filepath.
+writeEnvelope :: FilePath -> TypedScriptEnvelope -> IO ()
+writeEnvelope filepath = LBS.writeFile filepath . encodePretty

--- a/ply-core/src/Ply/Core/Serialize.hs
+++ b/ply-core/src/Ply/Core/Serialize.hs
@@ -1,4 +1,10 @@
-module Ply.Core.Serialize (writeEnvelope, serializeScript, serializeScriptCbor, serializeScriptCborHex) where
+module Ply.Core.Serialize (
+  writeEnvelope,
+  writeTypedScriptEnvolope,
+  serializeScript,
+  serializeScriptCbor,
+  serializeScriptCborHex,
+) where
 
 import Codec.Serialise (serialise)
 import Data.Aeson.Encode.Pretty (encodePretty)
@@ -14,6 +20,7 @@ import qualified Cardano.Binary as CBOR
 import Ply.Core.Types (
   ScriptRole,
   ScriptVersion,
+  TypedScriptEnvelope (..),
   TypedScriptEnvelope' (..),
   Typename,
  )
@@ -30,6 +37,11 @@ serializeScriptCbor = CBOR.serialize' . SBS.toShort . serializeScript
 -- | A showable hex string representing a serialized script in CBOR.
 serializeScriptCborHex :: Script -> Text
 serializeScriptCborHex = Txt.decodeUtf8 . Base16.encode . serializeScriptCbor
+
+-- | Write 'TypedScriptEnvelop' into file.
+writeTypedScriptEnvolope :: FilePath -> TypedScriptEnvelope -> IO ()
+writeTypedScriptEnvolope filepath (TypedScriptEnvelope ver role param descr script) =
+  writeEnvelope descr filepath ver role param script
 
 -- | Write a typed script into a "Ply.Core.Types.TypedScriptEnvelope".
 writeEnvelope ::

--- a/ply-core/src/Ply/Core/Serialize/Script.hs
+++ b/ply-core/src/Ply/Core/Serialize/Script.hs
@@ -4,14 +4,17 @@ module Ply.Core.Serialize.Script (
   serializeScriptCborHex,
 ) where
 
-import qualified Cardano.Binary as CBOR
-import Codec.Serialise (serialise)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short as SBS
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Txt
+
+import Codec.Serialise (serialise)
+
+import qualified Cardano.Binary as CBOR
+
 import Ply.LedgerExports.Common (Script)
 
 -- | Serialize a script into its raw form.

--- a/ply-core/src/Ply/Core/Serialize/Script.hs
+++ b/ply-core/src/Ply/Core/Serialize/Script.hs
@@ -1,0 +1,27 @@
+module Ply.Core.Serialize.Script (
+  serializeScript,
+  serializeScriptCbor,
+  serializeScriptCborHex,
+) where
+
+import qualified Cardano.Binary as CBOR
+import Codec.Serialise (serialise)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Short as SBS
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Txt
+import Ply.LedgerExports.Common (Script)
+
+-- | Serialize a script into its raw form.
+serializeScript :: Script -> ByteString
+serializeScript = LBS.toStrict . serialise
+
+-- | Serialize a script into CBOR.
+serializeScriptCbor :: Script -> ByteString
+serializeScriptCbor = CBOR.serialize' . SBS.toShort . serializeScript
+
+-- | A showable hex string representing a serialized script in CBOR.
+serializeScriptCborHex :: Script -> Text
+serializeScriptCborHex = Txt.decodeUtf8 . Base16.encode . serializeScriptCbor

--- a/ply-core/src/Ply/Core/Types.hs
+++ b/ply-core/src/Ply/Core/Types.hs
@@ -9,10 +9,7 @@ module Ply.Core.Types (
   Typename,
 ) where
 
-import qualified Cardano.Binary as CBOR
-import Codec.Serialise (deserialise)
 import Control.Exception (Exception)
-import Data.Aeson (object, (.=))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as LBS
@@ -22,9 +19,9 @@ import Data.Kind (Type)
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import GHC.Generics (Generic)
-import Ply.Core.Serialize.Script (serializeScript, serializeScriptCbor)
-import qualified Ply.LedgerExports.Common as Ledger
 
+import Codec.Serialise (deserialise)
+import Data.Aeson (object, (.=))
 import Data.Aeson.Types (
   FromJSON (parseJSON),
   ToJSON (toJSON),
@@ -35,10 +32,14 @@ import Data.Aeson.Types (
  )
 
 import Cardano.Binary (DecoderError, FromCBOR (fromCBOR))
+import qualified Cardano.Binary as CBOR
+
 import UntypedPlutusCore (DeBruijn, DefaultFun, DefaultUni, Program)
 
+import Ply.Core.Serialize.Script (serializeScript, serializeScriptCbor)
 import Ply.Core.Typename (Typename)
 import Ply.LedgerExports.Common (Script)
+import qualified Ply.LedgerExports.Common as Ledger
 
 -- | Compiled scripts that preserve script role and parameter types.
 type role TypedScript nominal nominal

--- a/ply-core/src/Ply/Core/Types.hs
+++ b/ply-core/src/Ply/Core/Types.hs
@@ -7,11 +7,10 @@ module Ply.Core.Types (
   ScriptReaderException (..),
   TypedScriptEnvelope (..),
   Typename,
-  serializeScriptCbor,
 ) where
 
 import qualified Cardano.Binary as CBOR
-import Codec.Serialise (deserialise, serialise)
+import Codec.Serialise (deserialise)
 import Control.Exception (Exception)
 import Data.Aeson (object, (.=))
 import Data.ByteString (ByteString)
@@ -23,6 +22,7 @@ import Data.Kind (Type)
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import GHC.Generics (Generic)
+import Ply.Core.Serialize.Script (serializeScript, serializeScriptCbor)
 import qualified Ply.LedgerExports.Common as Ledger
 
 import Data.Aeson.Types (
@@ -101,14 +101,6 @@ instance FromJSON TypedScriptEnvelope where
     prependFailure
       "parsing TypedScriptEnvelope' failed, "
       (typeMismatch "Object" invalid)
-
--- | Serialize a script into its raw form.
-serializeScript :: Script -> ByteString
-serializeScript = LBS.toStrict . serialise
-
--- | Serialize a script into CBOR.
-serializeScriptCbor :: Script -> ByteString
-serializeScriptCbor = CBOR.serialize' . SBS.toShort . serializeScript
 
 instance ToJSON TypedScriptEnvelope where
   toJSON (TypedScriptEnvelope ver rol params desc script) =

--- a/ply-core/src/Ply/Core/Types.hs
+++ b/ply-core/src/Ply/Core/Types.hs
@@ -5,19 +5,25 @@ module Ply.Core.Types (
   ScriptVersion (..),
   ScriptRole (..),
   ScriptReaderException (..),
-  TypedScriptEnvelope' (..),
   TypedScriptEnvelope (..),
   Typename,
+  serializeScriptCbor,
 ) where
 
+import qualified Cardano.Binary as CBOR
+import Codec.Serialise (deserialise, serialise)
 import Control.Exception (Exception)
 import Data.Aeson (object, (.=))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Lazy as LBS
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as SBS
 import Data.Kind (Type)
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import GHC.Generics (Generic)
+import qualified Ply.LedgerExports.Common as Ledger
 
 import Data.Aeson.Types (
   FromJSON (parseJSON),
@@ -28,7 +34,7 @@ import Data.Aeson.Types (
   (.:),
  )
 
-import Cardano.Binary (DecoderError)
+import Cardano.Binary (DecoderError, FromCBOR (fromCBOR))
 import UntypedPlutusCore (DeBruijn, DefaultFun, DefaultUni, Program)
 
 import Ply.Core.Typename (Typename)
@@ -49,28 +55,10 @@ data ScriptRole = ValidatorRole | MintingPolicyRole
 -- | Errors/Exceptions that may arise during Typed Script reading/parsing.
 data ScriptReaderException
   = AesonDecodeError String
-  | CBORDecodeError DecoderError
   | ScriptRoleError {expectedRole :: ScriptRole, actualRole :: ScriptRole}
   | ScriptTypeError {expectedType :: [Typename], actualType :: [Typename]}
   deriving stock (Eq, Show)
   deriving anyclass (Exception)
-
--- | JSON schema of the envelope we'll be using to represent typed scripts in the filesystem,
-data TypedScriptEnvelope' = TypedScriptEnvelope'
-  { -- | Plutus script version.
-    tsVersion' :: !ScriptVersion
-  , -- | Plutus script role, either a validator or a minting policy.
-    tsRole' :: !ScriptRole
-  , -- | List of extra parameter types to be applied before being treated as a validator/minting policy.
-    tsParamTypes' :: [Typename]
-  , -- | Description of the script, not semantically relevant.
-    tsDescription' :: !Text
-  , -- | The actual script in serialized CBOR form.
-    tsCbor' :: !ByteString
-  , -- | The actual script in raw serialized form.
-    tsRaw' :: !ByteString
-  }
-  deriving stock (Eq, Show)
 
 -- | This is essentially a post-processed version of 'TypedScriptEnvelope''.
 data TypedScriptEnvelope = TypedScriptEnvelope
@@ -87,25 +75,43 @@ data TypedScriptEnvelope = TypedScriptEnvelope
   }
   deriving stock (Eq, Show)
 
-instance FromJSON TypedScriptEnvelope' where
+newtype SerializedScript = SerializedScript {getSerializedScript :: ShortByteString}
+
+instance FromCBOR SerializedScript where
+  fromCBOR = SerializedScript . SBS.toShort <$> CBOR.fromCBOR
+
+cborToScript :: ByteString -> Either DecoderError Ledger.Script
+cborToScript x = deserialise . LBS.fromStrict . SBS.fromShort . getSerializedScript <$> CBOR.decodeFull' x
+
+instance FromJSON TypedScriptEnvelope where
   parseJSON (Object v) =
-    TypedScriptEnvelope'
+    TypedScriptEnvelope
       <$> v .: "version"
       <*> v .: "role"
       <*> v .: "params"
       <*> v .: "description"
-      <*> (parseJSONBase16 =<< v .: "cborHex")
-      <*> (parseJSONBase16 =<< v .: "rawHex")
+      <*> (parseAndDeserialize =<< v .: "cborHex")
     where
-      parseJSONBase16 v =
-        either fail pure . Base16.decode . Text.encodeUtf8 =<< parseJSON v
+      parseAndDeserialize v =
+        parseJSON v
+          >>= either fail (either (fail . show) pure . cborToScript)
+            . Base16.decode
+            . Text.encodeUtf8
   parseJSON invalid =
     prependFailure
       "parsing TypedScriptEnvelope' failed, "
       (typeMismatch "Object" invalid)
 
-instance ToJSON TypedScriptEnvelope' where
-  toJSON (TypedScriptEnvelope' ver rol params desc cborHex rawHex) =
+-- | Serialize a script into its raw form.
+serializeScript :: Script -> ByteString
+serializeScript = LBS.toStrict . serialise
+
+-- | Serialize a script into CBOR.
+serializeScriptCbor :: Script -> ByteString
+serializeScriptCbor = CBOR.serialize' . SBS.toShort . serializeScript
+
+instance ToJSON TypedScriptEnvelope where
+  toJSON (TypedScriptEnvelope ver rol params desc script) =
     toJSON $
       object
         [ "version" .= ver
@@ -115,6 +121,9 @@ instance ToJSON TypedScriptEnvelope' where
         , "cborHex" .= Text.decodeUtf8 (Base16.encode cborHex)
         , "rawHex" .= Text.decodeUtf8 (Base16.encode rawHex)
         ]
+    where
+      cborHex = serializeScriptCbor script
+      rawHex = serializeScript script
 
 -- | Version identifier for the Plutus script.
 data ScriptVersion = ScriptV1 | ScriptV2

--- a/ply-plutarch/ply-plutarch.cabal
+++ b/ply-plutarch/ply-plutarch.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          ply-plutarch
-version:       0.1.3
+version:       0.2.0
 author:        Chase <chase@mlabs.city>
 license:       MIT
 

--- a/ply-plutarch/src/Ply/Plutarch.hs
+++ b/ply-plutarch/src/Ply/Plutarch.hs
@@ -1,4 +1,4 @@
-module Ply.Plutarch (PlyArgOf, writeTypedScript, mkTypedScript) where
+module Ply.Plutarch (PlyArgOf, writeTypedScript, mkEnvelope) where
 
 import Ply.Plutarch.Class (PlyArgOf)
-import Ply.Plutarch.TypedWriter (mkTypedScript, writeTypedScript)
+import Ply.Plutarch.TypedWriter (mkEnvelope, writeTypedScript)

--- a/ply-plutarch/src/Ply/Plutarch.hs
+++ b/ply-plutarch/src/Ply/Plutarch.hs
@@ -1,4 +1,4 @@
-module Ply.Plutarch (PlyArgOf, writeTypedScript) where
+module Ply.Plutarch (PlyArgOf, writeTypedScript, mkTypedScript) where
 
 import Ply.Plutarch.Class (PlyArgOf)
-import Ply.Plutarch.TypedWriter (writeTypedScript)
+import Ply.Plutarch.TypedWriter (mkTypedScript, writeTypedScript)

--- a/ply-plutarch/src/Ply/Plutarch/TypedWriter.hs
+++ b/ply-plutarch/src/Ply/Plutarch/TypedWriter.hs
@@ -58,7 +58,7 @@ writeTypedScript ::
 writeTypedScript conf descr fp target =
   either (throwIO . userError . Txt.unpack) (writeEnvelope fp) envelope
   where
-    envelope = mkEnvelope conf target descr
+    envelope = mkEnvelope conf descr target
 
 {- | Class of Plutarch function types that can be written to the filesystem as 'TypedScript's.
 
@@ -82,10 +82,10 @@ mkEnvelope ::
   forall ptype.
   TypedWriter ptype =>
   Config ->
-  ClosedTerm ptype ->
   Text ->
+  ClosedTerm ptype ->
   Either Text TypedScriptEnvelope
-mkEnvelope conf pterm descr =
+mkEnvelope conf descr pterm =
   pure (TypedScriptEnvelope ver)
     <*> pure rl
     <*> pure paramTypes

--- a/ply-plutarch/src/Ply/Plutarch/TypedWriter.hs
+++ b/ply-plutarch/src/Ply/Plutarch/TypedWriter.hs
@@ -7,7 +7,7 @@ module Ply.Plutarch.TypedWriter (
   type VersionOf,
   type PlyParamsOf,
   writeTypedScript,
-  makeTypedScript,
+  mkTypedScript,
   typedWriterInfo,
 ) where
 
@@ -37,7 +37,7 @@ import Ply.Core.Internal.Reify (
   reifyTypenames,
   reifyVersion,
  )
-import Ply.Core.Serialize (writeEnvelope)
+import Ply.Core.Serialize (writeTypedScriptEnvolope)
 
 import Ply.Plutarch.Class (PlyArgOf)
 
@@ -59,15 +59,15 @@ writeTypedScript ::
   ClosedTerm pt ->
   IO ()
 writeTypedScript conf descr fp target =
-  either (throwIO . userError . Txt.unpack) (writeEnvelope descr fp ver rl paramTypes) scrpt
+  either (throwIO . userError . Txt.unpack) (writeTypedScriptEnvolope fp) envelope
   where
-    (ver, rl, paramTypes, scrpt) = typedWriterInfo conf target
+    envelope = mkTypedScript conf descr target
 
 {- | Make a 'TypedScriptEnvelope' from Plutarch validator or minting policy.
 
 Unlike 'writeTypedScript', it does not write to filesystem.
 -}
-makeTypedScript ::
+mkTypedScript ::
   TypedWriter pt =>
   -- | Plutarch compiler configuration which will be used to compile the script.
   Config ->
@@ -76,7 +76,7 @@ makeTypedScript ::
   -- | The parameterized Plutarch validator/minting policy.
   ClosedTerm pt ->
   Either Text TypedScriptEnvelope
-makeTypedScript conf descr target = do
+mkTypedScript conf descr target = do
   let (ver, rl, paramTypes, scrpt) = typedWriterInfo conf target
 
   scrpt' <- scrpt

--- a/ply-plutarch/test/Spec.hs
+++ b/ply-plutarch/test/Spec.hs
@@ -36,18 +36,18 @@ testHelper ::
   Assertion
 testHelper expectedTypes = do
   let (actualVersion0, actualRole0, actualTypes0, _) =
-        unEnvelope $ mkEnvelope @(PTypeWith PLedgerV1.PValidator ptypeList) def (punsafeCoerce $ plam id) mempty
+        unEnvelope $ mkEnvelope @(PTypeWith PLedgerV1.PValidator ptypeList) def mempty (punsafeCoerce $ plam id)
   actualRole0 @?= ValidatorRole
   let (actualVersion1, actualRole1, actualTypes1, _) =
-        unEnvelope $ mkEnvelope @(PTypeWith PLedgerV1.PMintingPolicy ptypeList) def (punsafeCoerce $ plam id) mempty
+        unEnvelope $ mkEnvelope @(PTypeWith PLedgerV1.PMintingPolicy ptypeList) def mempty (punsafeCoerce $ plam id)
   actualRole1 @?= MintingPolicyRole
   actualVersion0 @?= ScriptV1
   actualVersion0 @?= actualVersion1
   let (actualVersion2, actualRole2, actualTypes2, _) =
-        unEnvelope $ mkEnvelope @(PTypeWith PLedgerV2.PValidator ptypeList) def (punsafeCoerce $ plam id) mempty
+        unEnvelope $ mkEnvelope @(PTypeWith PLedgerV2.PValidator ptypeList) def mempty (punsafeCoerce $ plam id)
   actualRole2 @?= ValidatorRole
   let (actualVersion3, actualRole3, actualTypes3, _) =
-        unEnvelope $ mkEnvelope @(PTypeWith PLedgerV2.PMintingPolicy ptypeList) def (punsafeCoerce $ plam id) mempty
+        unEnvelope $ mkEnvelope @(PTypeWith PLedgerV2.PMintingPolicy ptypeList) def mempty (punsafeCoerce $ plam id)
   actualRole3 @?= MintingPolicyRole
   actualVersion2 @?= ScriptV2
   actualVersion2 @?= actualVersion3

--- a/ply-plutarch/test/Spec.hs
+++ b/ply-plutarch/test/Spec.hs
@@ -11,11 +11,18 @@ import Test.Tasty.HUnit
 import Plutarch.Api.V1 as PLedgerV1
 import Plutarch.Api.V2 as PLedgerV2
 import Plutarch.Prelude
+import Plutarch.Unsafe (punsafeCoerce)
 import PlutusLedgerApi.V1
 import qualified PlutusTx.AssocMap as PlutusMap
 
-import Ply (ScriptRole (MintingPolicyRole, ValidatorRole), ScriptVersion (ScriptV1, ScriptV2), Typename, typeName)
-import Ply.Plutarch.TypedWriter (TypedWriter, typedWriterInfo)
+import Ply (
+  ScriptRole (MintingPolicyRole, ValidatorRole),
+  ScriptVersion (ScriptV1, ScriptV2),
+  TypedScriptEnvelope (TypedScriptEnvelope),
+  Typename,
+  typeName,
+ )
+import Ply.Plutarch.TypedWriter (TypedWriter, mkEnvelope)
 
 -- | Ensure 'typedWriterInfo @ptype' yields the expected 'ScriptRole' and '[Typename]'.
 testHelper ::
@@ -29,18 +36,18 @@ testHelper ::
   Assertion
 testHelper expectedTypes = do
   let (actualVersion0, actualRole0, actualTypes0, _) =
-        typedWriterInfo @(PTypeWith PLedgerV1.PValidator ptypeList) def undefined
+        unEnvelope $ mkEnvelope @(PTypeWith PLedgerV1.PValidator ptypeList) def (punsafeCoerce $ plam id) mempty
   actualRole0 @?= ValidatorRole
   let (actualVersion1, actualRole1, actualTypes1, _) =
-        typedWriterInfo @(PTypeWith PLedgerV1.PMintingPolicy ptypeList) def undefined
+        unEnvelope $ mkEnvelope @(PTypeWith PLedgerV1.PMintingPolicy ptypeList) def (punsafeCoerce $ plam id) mempty
   actualRole1 @?= MintingPolicyRole
   actualVersion0 @?= ScriptV1
   actualVersion0 @?= actualVersion1
   let (actualVersion2, actualRole2, actualTypes2, _) =
-        typedWriterInfo @(PTypeWith PLedgerV2.PValidator ptypeList) def undefined
+        unEnvelope $ mkEnvelope @(PTypeWith PLedgerV2.PValidator ptypeList) def (punsafeCoerce $ plam id) mempty
   actualRole2 @?= ValidatorRole
   let (actualVersion3, actualRole3, actualTypes3, _) =
-        typedWriterInfo @(PTypeWith PLedgerV2.PMintingPolicy ptypeList) def undefined
+        unEnvelope $ mkEnvelope @(PTypeWith PLedgerV2.PMintingPolicy ptypeList) def (punsafeCoerce $ plam id) mempty
   actualRole3 @?= MintingPolicyRole
   actualVersion2 @?= ScriptV2
   actualVersion2 @?= actualVersion3
@@ -48,6 +55,9 @@ testHelper expectedTypes = do
   actualTypes0 @?= actualTypes1
   actualTypes0 @?= actualTypes2
   actualTypes0 @?= actualTypes3
+  where
+    unEnvelope (Right (TypedScriptEnvelope ver rl param _ scr)) = (ver, rl, param, scr)
+    unEnvelope (Left t) = error $ show t
 
 baselineTest :: Assertion
 baselineTest = testHelper @'[] []
@@ -55,7 +65,7 @@ baselineTest = testHelper @'[] []
 tests :: TestTree
 tests =
   testGroup
-    "typedWriterInfo works as expected"
+    "mkEnvelope works as expected"
     [ testCase "@PValidator/@PMintingPolicy" baselineTest
     , testCase "@(PBool :--> _)" $
         testHelper @'[PBool] [typeName @Bool]


### PR DESCRIPTION
It allows building `TypedScriptEnvelope` directly from Plutarch term.

It comes handy for onchain tests as we don't have to write every script to file and read them again.  

