### PR TITLE
add missing PlyArgOf instance

### DIFF
--- a/ply-plutarch/src/Ply/Plutarch/Class.hs
+++ b/ply-plutarch/src/Ply/Plutarch/Class.hs
@@ -6,6 +6,7 @@ import Data.ByteString (ByteString)
 import Data.Text (Text)
 
 import Plutarch.Api.V1 as PLedgerV1
+import Plutarch.Api.V1.Scripts (PScriptHash)
 import Plutarch.Prelude
 import PlutusLedgerApi.V1 as LedgerV1
 import qualified PlutusTx.AssocMap as PlutusMap
@@ -49,6 +50,8 @@ type instance PlyArgOf PCurrencySymbol = CurrencySymbol
 type instance PlyArgOf PTokenName = TokenName
 
 type instance PlyArgOf PPubKeyHash = PubKeyHash
+
+type instance PlyArgOf PScriptHash = ScriptHash
 
 type instance PlyArgOf PPOSIXTime = POSIXTime
 


### PR DESCRIPTION
An instance of `PlyArgOf` for the `PScriptHash` type was missing. This PR adds it. I'm sure there's a few more missing, but this is the only one that I found. It causes a pretty rough error.