### PR TITLE
Handle GHC.Num.Integer module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.1 - Hotfix for Integer parameters
+
+- Older GHCs export 'Integer' at "GHC.Num.Integer", but older ones have it at "GHC.Integer.Type". So two GHC version discrepancy between onchain and offchain where one of the typed scripts used integers broke everything.
+
+  Ply will now rename the old module (if encountered) to be like the new one.
+
 # 0.3.0 - Plutus update, Plutarch 1.3, API changes
 
 There is no `Script` type in upstream Plutus anymore. As a result, `TypedScript` holds the UPLC program itself.

--- a/ply-core/ply-core.cabal
+++ b/ply-core/ply-core.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          ply-core
-version:       0.3.0
+version:       0.3.1
 author:        Chase <chase@mlabs.city>
 license:       MIT
 

--- a/ply-core/src/Ply/Core/Typename.hs
+++ b/ply-core/src/Ply/Core/Typename.hs
@@ -21,7 +21,7 @@ No specific guarantees are given as per the representation of the 'Typename', as
 However, typenames of 2 different types (different module) won't be the same.
 -}
 typeName :: forall a. Typeable a => Typename
-typeName = Typename . Txt.pack $ srcModuleName ++ ':' : tyConName tyCon
+typeName = Typename . Txt.pack . toNewGHCIntegerModuleName $ srcModuleName ++ ':' : tyConName tyCon
   where
     srcModuleName = toNewLedgerModuleName $ tyConModule tyCon
     tyCon = typeRepTyCon $ typeRep @a
@@ -53,6 +53,11 @@ toNewLedgerModuleName (splitAt oldLedgerModuleNameLen -> (!prefx, !sufx))
         then "" -- The Plutus.Vx.Ledger.Api module got renamed to just PlutusLedgerApi.Vx
         else sufx
   | otherwise = prefx ++ sufx
+
+-- Older GHCs export 'Integer' at "GHC.Num.Integer", but older ones have it at "GHC.Integer.Type"
+toNewGHCIntegerModuleName :: String -> String
+toNewGHCIntegerModuleName "GHC.Integer.Type:Integer" = "GHC.Num.Integer:Integer"
+toNewGHCIntegerModuleName x = x
 
 oldLedgerModuleNameLen :: Int
 oldLedgerModuleNameLen = length oldLedgerV1ModuleName

--- a/ply-plutarch/ply-plutarch.cabal
+++ b/ply-plutarch/ply-plutarch.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          ply-plutarch
-version:       0.3.0
+version:       0.3.1
 author:        Chase <chase@mlabs.city>
 license:       MIT
 


### PR DESCRIPTION
Older GHCs export 'Integer' at "GHC.Num.Integer", but older ones have it at "GHC.Integer.Type". So two GHC version discrepancy between onchain and offchain where one of the typed scripts used integers broke everything.