### PR TITLE
`ply-core` compatiblity with plutus haskell library version `1.6.0.0`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,3 @@
-index-state: 2022-10-31T00:00:00Z
-
 repository cardano-haskell-packages
   url: https://input-output-hk.github.io/cardano-haskell-packages
   secure: True
@@ -11,17 +9,18 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
-index-state: cardano-haskell-packages 2022-10-31T00:00:00Z
+-- repeating the index-state for hackage to work around hackage.nix parsing limitation
+index-state: 2023-06-06T00:00:00Z
+
+index-state:
+  , hackage.haskell.org 2023-06-06T00:00:00Z
+  , cardano-haskell-packages 2023-06-05T06:39:32Z
 
 packages:
   ./ply-plutarch
   ./ply-core
   ./genPurs
   ./example
-
-write-ghc-environment-files: never
-
-tests: true
 
 test-show-details: direct
 

--- a/cabal.project
+++ b/cabal.project
@@ -9,7 +9,7 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
--- repeating the index-state for hackage to work around hackage.nix parsing limitation
+-- Repeating the index-state for hackage to work around hackage.nix parsing limitation.
 index-state: 2023-06-06T00:00:00Z
 
 index-state:
@@ -17,10 +17,10 @@ index-state:
   , cardano-haskell-packages 2023-06-05T06:39:32Z
 
 packages:
-  ./ply-plutarch
+--  ./ply-plutarch
   ./ply-core
-  ./genPurs
-  ./example
+--  ./genPurs
+--  ./example
 
 test-show-details: direct
 

--- a/ply-core/ply-core.cabal
+++ b/ply-core/ply-core.cabal
@@ -27,9 +27,9 @@ common common-deps
     , bytestring
     , cardano-binary
     , containers
-    , plutus-core  == 1.6.0.0
-    , plutus-ledger-api  == 1.6.0.0
-    , plutus-tx  == 1.6.0.0
+    , plutus-core         >= 1.6.0.0 && < 1.8
+    , plutus-ledger-api   >= 1.6.0.0 && < 1.8
+    , plutus-tx           >= 1.6.0.0 && < 1.8
     , serialise
     , tagged
     , text

--- a/ply-core/ply-core.cabal
+++ b/ply-core/ply-core.cabal
@@ -27,9 +27,9 @@ common common-deps
     , bytestring
     , cardano-binary
     , containers
-    , plutus-core
-    , plutus-ledger-api
-    , plutus-tx
+    , plutus-core  == 1.6.0.0
+    , plutus-ledger-api  == 1.6.0.0
+    , plutus-tx  == 1.6.0.0
     , serialise
     , tagged
     , text

--- a/ply-core/src/Ply/Core/Types.hs
+++ b/ply-core/src/Ply/Core/Types.hs
@@ -34,7 +34,7 @@ import Data.Aeson.Types (
 import Cardano.Binary as CBOR (DecoderError)
 import qualified Cardano.Binary as CBOR
 
-import PlutusLedgerApi.Common (deserialiseUPLC, serialiseUPLC)
+import PlutusLedgerApi.Common (uncheckedDeserialiseUPLC, serialiseUPLC)
 import UntypedPlutusCore (DeBruijn, DefaultFun, DefaultUni, Program)
 
 import Ply.Core.Serialize.Script (serializeScriptCbor)
@@ -86,7 +86,7 @@ data TypedScriptEnvelope = TypedScriptEnvelope
   deriving stock (Eq, Show)
 
 cborToScript :: ByteString -> Either DecoderError UPLCProgram
-cborToScript x = deserialiseUPLC <$> CBOR.decodeFull' x
+cborToScript x = uncheckedDeserialiseUPLC <$> CBOR.decodeFull' x
 
 instance FromJSON TypedScriptEnvelope where
   parseJSON (Object v) =

--- a/ply-core/src/Ply/Core/UPLC.hs
+++ b/ply-core/src/Ply/Core/UPLC.hs
@@ -5,21 +5,22 @@ import Data.String (IsString)
 
 import PlutusCore (Some (Some), ValueOf (ValueOf))
 import qualified PlutusCore as PLC
+import qualified PlutusCore.Version as PLC
 import UntypedPlutusCore (
   DeBruijn (DeBruijn),
   DefaultFun,
   DefaultUni,
   Index,
   Program (Program),
-  Term (Apply, Builtin, Constant, Delay, Error, Force, LamAbs, Var),
+  Term (Apply, Builtin, Constant, Delay, Error, Force, LamAbs, Var, Constr, Case),
   Version,
  )
 
-pattern DefaultVersion :: Version ()
+pattern DefaultVersion :: Version
 pattern DefaultVersion <-
-  ((== PLC.defaultVersion ()) -> True)
+  ((== PLC.plcVersion100) -> True)
   where
-    DefaultVersion = PLC.defaultVersion ()
+    DefaultVersion = PLC.plcVersion100
 
 {- | Apply a 'DefaultUni' constant to given UPLC program, inlining if necessary.
  TODO: Subst optimizations when 'Apply'ing over non 'LamAbs' stuff as well, e.g chain of 'Apply'ies.
@@ -63,6 +64,8 @@ _termIdOf (Apply () _ _) = "Apply"
 _termIdOf (LamAbs () _ _) = "LamAbs"
 _termIdOf (Delay () _) = "Delay"
 _termIdOf (Force () _) = "Force"
+_termIdOf (Constr () _ _) = "Constr"
+_termIdOf (Case () _ _) = "Case"
 
 isSmallConstant :: Some (ValueOf DefaultUni) -> Bool
 isSmallConstant c = case c of


### PR DESCRIPTION
These were the changes I needed to do to make it compatible with mentioned dependency but other packages (besides `ply-core`) are broke as they depend upon plutarch which in turn depends upon older plutus version.